### PR TITLE
Switch last occurrence of print() to write() in Thermal::write()

### DIFF
--- a/Thermal.cpp
+++ b/Thermal.cpp
@@ -96,11 +96,12 @@ void Thermal::write(uint8_t c) {
   Serial.print(c, HEX);
 #if ARDUINO >= 100
   Serial.print(" ("); Serial.write(c); Serial.println(")");
+  _printer->write(c);
 #else
   Serial.print(" ("); Serial.print(c, BYTE); Serial.println(")");
+  _printer->print(c);
 #endif
 
-  _printer->print(c);
   delay(1);
 
 #if ARDUINO >= 100


### PR DESCRIPTION
On my setup (OSX w/ Arduino 1.0 RC 2), I needed to make this one change to get printing working.  Without it, the printer appeared to be dumping out the ASCII decimal codes instead of the characters.
