### PR TITLE
Added support for bitmaps in RAM

### DIFF
--- a/Adafruit_Thermal.cpp
+++ b/Adafruit_Thermal.cpp
@@ -385,7 +385,7 @@ void Adafruit_Thermal::underlineOff() {
   underlineOn(0);
 }
 
-void Adafruit_Thermal::printBitmap(int w, int h, const uint8_t *bitmap) {
+void Adafruit_Thermal::printBitmap(int w, int h, const uint8_t *bitmap, bool fromProgMem) {
   int rowBytes, rowBytesClipped, rowStart, chunkHeight, x, y, i;
 
   rowBytes        = (w + 7) / 8; // Round up to next byte boundary
@@ -400,7 +400,7 @@ void Adafruit_Thermal::printBitmap(int w, int h, const uint8_t *bitmap) {
 
     for(y=0; y < chunkHeight; y++) {
       for(x=0; x < rowBytesClipped; x++, i++) {
-        PRINTER_PRINT(pgm_read_byte(bitmap + i));
+          PRINTER_PRINT(fromProgMem ? pgm_read_byte(bitmap + i) : *(bitmap+i));
       }
       i += rowBytes - rowBytesClipped;
     }

--- a/Adafruit_Thermal.h
+++ b/Adafruit_Thermal.h
@@ -89,7 +89,7 @@ class Adafruit_Thermal : public Print {
     printBarcode(char * text, uint8_t type),
     setBarcodeHeight(int val=50),
 
-    printBitmap(int w, int h, const uint8_t *bitmap),
+    printBitmap(int w, int h, const uint8_t *bitmap, bool fromProgMem = true),
     printBitmap(int w, int h, Stream *stream),
     printBitmap(Stream *stream),
 


### PR DESCRIPTION
I wanted to dynamically generate patterns on the Arduino to print on my thermal printer, so I added an optional flag to the printBitmap function which can be set to False in order to load bitmap data from RAM instead of from PROGMEM. When the 4th paramater is absent, it will load from PROGMEM (for backward-compatibility).
