### PR TITLE
Add printer.setFont('B') command for choosing the second font

### DIFF
--- a/Adafruit_Thermal.h
+++ b/Adafruit_Thermal.h
@@ -86,6 +86,7 @@ class Adafruit_Thermal : public Print {
 
     setSize(char value),
     setLineHeight(int val=32),
+    setFont(char value),          // A (default, 12x24) or B (small, 9x17)
 
     printBarcode(char * text, uint8_t type),
     setBarcodeHeight(int val=50),
@@ -101,6 +102,11 @@ class Adafruit_Thermal : public Print {
 
     setCharSpacing(int spacing), // Not working
     tab();                       // Not working
+
+  uint8_t 
+    getMaxColumn(), 
+    getCharHeight(),
+    getCharWidth();
 
   bool hasPaper();
 
@@ -119,6 +125,7 @@ class Adafruit_Thermal : public Print {
     column,        // Last horizontal column printed
     maxColumn,     // Page width (output 'wraps' at this point)
     charHeight,    // Height of characters, in 'dots'
+    charWidth,     // Width of characters, in 'dots'
     lineSpacing,   // Inter-line spacing (not line height), in dots
     barcodeHeight; // Barcode height in dots, not including text
   unsigned long
@@ -133,6 +140,7 @@ class Adafruit_Thermal : public Print {
   void
     setPrintMode(uint8_t mask),
     unsetPrintMode(uint8_t mask),
+    adjustCharValues(uint8_t mask),
     writePrintMode(),
     writeBytes(uint8_t a),
     writeBytes(uint8_t a, uint8_t b),

--- a/examples/printertest/fonttest.ino
+++ b/examples/printertest/fonttest.ino
@@ -1,0 +1,47 @@
+/*
+ * Two Font Sizes, regular and compressed, for Adafruit Thermal Printer:
+ * http://www.adafruit.com/products/597 and
+ * Leigh L. Klotz, Jr <Leigh@WA5ZNU.org>
+ */
+
+#include <Process.h>
+#include "SoftwareSerial.h"
+#include "Adafruit_Thermal.h"
+#include <avr/pgmspace.h>
+
+int printer_RX_Pin = 5;  // This is the green wire
+int printer_TX_Pin = 6;  // This is the yellow wire
+
+Adafruit_Thermal printer(printer_RX_Pin, printer_TX_Pin);
+
+void testFont(char font, char size, char *msg) {
+  printer.setFont(font); 
+  printer.setSize(size); 
+  printer.println(msg);
+  printer.print("maxCol=");
+  printer.print(printer.getMaxColumn());
+  printer.print(" charHeight=");
+  printer.print(printer.getCharHeight());
+  printer.print(" charWidth=");
+  printer.println(printer.getCharWidth());
+  printer.print("<");
+  for (uint8_t i = 1; i < printer.getMaxColumn()-2; i++) {
+      printer.print('-');
+  }
+  printer.println(">");
+}
+
+void setup() {
+  Bridge.begin();
+  printer.begin();
+  testFont('A', 'S', "Default Font Small");
+  testFont('A', 'M', "Default Font Medium");
+  testFont('A', 'L', "Default Font Large");
+  testFont('B', 'S', "Compressed Font Small");
+  testFont('B', 'M', "Compressed Font Medium");
+  testFont('B', 'L', "Compressed Font Large");
+}
+
+void loop() {
+  // Do nothing here.
+}

--- a/keywords.txt
+++ b/keywords.txt
@@ -29,6 +29,7 @@ boldOff	KEYWORD2
 sleep	KEYWORD2
 wake	KEYWORD2
 setSize	KEYWORD2
+setFont	KEYWORD2
 setBarcodeHeight	KEYWORD2
 feed	KEYWORD2
 tab	KEYWORD2
@@ -38,6 +39,9 @@ doubleHeightOff	KEYWORD2
 inverseOn	KEYWORD2
 inverseOff	KEYWORD2
 setDefault	KEYWORD2
+getMaxColumn	KEYWORD2
+getCharHeight	KEYWORD2
+getCharWidth	KEYWORD2
 
 
 


### PR DESCRIPTION
As decribed here:
    http://forums.adafruit.com/viewtopic.php?f=19&t=32659
the printer currently sold by Adafruit supports two fonts.  The second font ("B") allows printing 42 characters per line in the small size.  The printer's own self-test prints out this font and calls it "Font B."  The default font is Font A and is 12x24 pixels.  The "compressed" font is Font B and it is 9x17.

This pull request add the "compressed" font with setFont('B'), and updates the width and height calculations so that they are based on character width and line width in pixels, rather than being hand calculated.  It also add saccessors for char size getCharWidth, getCharHeight, getMaxColumn. 

In examples, there is also a new test program.
