### PR TITLE
2.68 firmware printer setting fixes

### DIFF
--- a/Adafruit_Thermal.cpp
+++ b/Adafruit_Thermal.cpp
@@ -321,11 +321,29 @@ void Adafruit_Thermal::inverseOff(){
 }
 
 void Adafruit_Thermal::upsideDownOn(){
-  setPrintMode(UPDOWN_MASK);
+  #if PRINTER_FIRMWARE >= 268
+    writeBytes(ASCII_ESC, '{', 1);
+  #else
+    setPrintMode(UPDOWN_MASK);
+  #endif
 }
 
 void Adafruit_Thermal::upsideDownOff(){
-  unsetPrintMode(UPDOWN_MASK);
+  #if PRINTER_FIRMWARE >= 268
+    writeBytes(ASCII_ESC, '{', 0);
+  #else
+    unsetPrintMode(UPDOWN_MASK);
+  #endif
+}
+
+// only tested on firmware 2.68
+void Adafruit_Thermal::sidewaysOn(){
+  writeBytes(ASCII_ESC, 'V', 1);
+}
+
+// only tested on firmware 2.68
+void Adafruit_Thermal::sidewaysOff(){
+  writeBytes(ASCII_ESC, 'V', 0);
 }
 
 void Adafruit_Thermal::doubleHeightOn(){

--- a/Adafruit_Thermal.h
+++ b/Adafruit_Thermal.h
@@ -157,6 +157,8 @@ class Adafruit_Thermal : public Print {
     setMaxChunkHeight(int val=256),
     setSize(char value),
     setTimes(unsigned long, unsigned long),
+    sidewaysOn(),
+    sidewaysOff(),
     sleep(),
     sleepAfter(uint16_t seconds),
     strikeOff(),


### PR DESCRIPTION
Fixes the following printer settings for printers with 2.68 firmware (I don't have a printer with any other firmware to test with)
- Upside Down
- Inverse
- Sideways
