### PR TITLE
Basic fix for issue #23

### DIFF
--- a/Adafruit_Thermal.cpp
+++ b/Adafruit_Thermal.cpp
@@ -66,9 +66,9 @@ void Adafruit_Thermal::timeoutSet(unsigned long x) {
 // This function waits (if necessary) for the prior task to complete.
 void Adafruit_Thermal::timeoutWait() {
   if(dtrEnabled) {
-    while(digitalRead(dtrPin) == HIGH);
+    while(digitalRead(dtrPin) == HIGH){yield();};
   } else {
-    while((long)(micros() - resumeTime) < 0L); // (syntax is rollover-proof)
+    while((long)(micros() - resumeTime) < 0L){yield();}; // (syntax is rollover-proof)
   }
 }
 


### PR DESCRIPTION
Adding yield() enables the ESP8266 to do other things while waiting and prevents reboots due to watchdog timer timeouts..

I had a hard tme to find out that the while-loop was the cause for the reboots....

That´s exactly what yield() is for -> Passes control to other tasks when called. Ideally yield() should be used in functions that will take awhile to complete.
