### PR TITLE
fix compiler warning

### DIFF
--- a/Adafruit_Thermal.cpp
+++ b/Adafruit_Thermal.cpp
@@ -278,7 +278,7 @@ void Adafruit_Thermal::setBarcodeHeight(uint8_t val) { // Default is 50
   writeBytes(ASCII_GS, 'h', val);
 }
 
-void Adafruit_Thermal::printBarcode(char *text, uint8_t type) {
+void Adafruit_Thermal::printBarcode(const char *text, uint8_t type) {
   feed(1); // Recent firmware can't print barcode w/o feed first???
   writeBytes(ASCII_GS, 'H', 2);    // Print label below barcode
   writeBytes(ASCII_GS, 'w', 3);    // Barcode width 3 (0.375/1.0mm thin/thick)

--- a/Adafruit_Thermal.h
+++ b/Adafruit_Thermal.h
@@ -193,7 +193,7 @@ public:
      * @param text The specified text/number (the meaning varies based on the type of barcode) and type to write to the barcode
      * @param type Value from the datasheet or class-level variables like UPC-A. Note the type value changes depending on the firmware version so use class-level values where possible
      */
-    printBarcode(char *text, uint8_t type),
+    printBarcode(const char *text, uint8_t type),
     /*!
      * @brief Prints a bitmap
      * @param w Width of the image in pixels


### PR DESCRIPTION
## Fix

warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]

## Change

Old function 
```c++
    void  printBarcode(char *text, uint8_t type)
```
to
```c++
    void  printBarcode(const char *text, uint8_t type)
```

Writable array `char *` is not required by function, so could be changed to `const char *`.

## Example

From `A_printertest`:
```c++
  printer.printBarcode("ADAFRUT", CODE39);
```

## Issues

fixes #31