### PR TITLE
Refactor firmware version control

### DIFF
--- a/Adafruit_Thermal.cpp
+++ b/Adafruit_Thermal.cpp
@@ -142,7 +142,7 @@ void Adafruit_Thermal::writeBytes(uint8_t a, uint8_t b, uint8_t c, uint8_t d) {
 // The inherited Print class handles the rest!
 size_t Adafruit_Thermal::write(uint8_t c) {
 
-  if (c != 0x13) { // Strip carriage returns
+  if (c != 13) { // Strip carriage returns
     timeoutWait();
     stream->write(c);
     unsigned long d = BYTE_TIME;

--- a/Adafruit_Thermal.cpp
+++ b/Adafruit_Thermal.cpp
@@ -169,7 +169,9 @@ size_t Adafruit_Thermal::write(uint8_t c) {
   @def printBreakTime
   Printing break time. Default: 500 uS
 */
-void Adafruit_Thermal::begin(uint8_t heatTime) {
+void Adafruit_Thermal::begin(uint16_t version) {
+
+  firmware = version;
 
   // The printer can't start receiving data immediately upon power up --
   // it needs a moment to cold boot and initialize.  Allow at least 1/2
@@ -179,26 +181,7 @@ void Adafruit_Thermal::begin(uint8_t heatTime) {
   wake();
   reset();
 
-  // ESC 7 n1 n2 n3 Setting Control Parameter Command
-  // n1 = "max heating dots" 0-255 -- max number of thermal print head
-  //      elements that will fire simultaneously.  Units = 8 dots (minus 1).
-  //      Printer default is 7 (64 dots, or 1/6 of 384-dot width), this code
-  //      sets it to 11 (96 dots, or 1/4 of width).
-  // n2 = "heating time" 3-255 -- duration that heating dots are fired.
-  //      Units = 10 us.  Printer default is 80 (800 us), this code sets it
-  //      to value passed (default 120, or 1.2 ms -- a little longer than
-  //      the default because we've increased the max heating dots).
-  // n3 = "heating interval" 0-255 -- recovery time between groups of
-  //      heating dots on line; possibly a function of power supply.
-  //      Units = 10 us.  Printer default is 2 (20 us), this code sets it
-  //      to 40 (throttled back due to 2A supply).
-  // More heating dots = more peak current, but faster printing speed.
-  // More heating time = darker print, but slower printing speed and
-  // possibly paper 'stiction'.  More heating interval = clearer print,
-  // but slower printing speed.
-
-  writeBytes(ASCII_ESC, '7');   // Esc 7 (print settings)
-  writeBytes(11, heatTime, 40); // Heating dots, heat time, heat interval
+  setHeatConfig();
 
   // Print density description from manual:
   // DC2 # n Set printing density
@@ -236,12 +219,12 @@ void Adafruit_Thermal::reset() {
   lineSpacing = 6;
   barcodeHeight = 50;
 
-#if PRINTER_FIRMWARE >= 264
-  // Configure tab stops on recent printers
-  writeBytes(ASCII_ESC, 'D'); // Set tab stops...
-  writeBytes(4, 8, 12, 16);   // ...every 4 columns,
-  writeBytes(20, 24, 28, 0);  // 0 marks end-of-list.
-#endif
+  if (firmware >= 264) {
+    // Configure tab stops on recent printers
+    writeBytes(ASCII_ESC, 'D'); // Set tab stops...
+    writeBytes(4, 8, 12, 16);   // ...every 4 columns,
+    writeBytes(20, 24, 28, 0);  // 0 marks end-of-list.
+  }
 }
 
 // Reset text formatting parameters.
@@ -280,22 +263,24 @@ void Adafruit_Thermal::setBarcodeHeight(uint8_t val) { // Default is 50
 
 void Adafruit_Thermal::printBarcode(const char *text, uint8_t type) {
   feed(1); // Recent firmware can't print barcode w/o feed first???
+  if (firmware >= 264)
+    type += 65;
   writeBytes(ASCII_GS, 'H', 2);    // Print label below barcode
   writeBytes(ASCII_GS, 'w', 3);    // Barcode width 3 (0.375/1.0mm thin/thick)
   writeBytes(ASCII_GS, 'k', type); // Barcode type (listed in .h file)
-#if PRINTER_FIRMWARE >= 264
-  int len = strlen(text);
-  if (len > 255)
-    len = 255;
-  writeBytes(len); // Write length byte
-  for (uint8_t i = 0; i < len; i++)
-    writeBytes(text[i]); // Write string sans NUL
-#else
-  uint8_t c, i = 0;
-  do { // Copy string + NUL terminator
-    writeBytes(c = text[i++]);
-  } while (c);
-#endif
+  if (firmware >= 264) {
+    int len = strlen(text);
+    if (len > 255)
+      len = 255;
+    writeBytes(len); // Write length byte
+    for (uint8_t i = 0; i < len; i++)
+      writeBytes(text[i]); // Write string sans NUL
+  } else {
+    uint8_t c, i = 0;
+    do { // Copy string + NUL terminator
+      writeBytes(c = text[i++]);
+    } while (c);
+  }
   timeoutSet((barcodeHeight + 40) * dotPrintTime);
   prevByte = '\n';
 }
@@ -335,35 +320,35 @@ void Adafruit_Thermal::normal() {
 }
 
 void Adafruit_Thermal::inverseOn() {
-#if PRINTER_FIRMWARE >= 268
-  writeBytes(ASCII_GS, 'B', 1);
-#else
-  setPrintMode(INVERSE_MASK);
-#endif
+  if (firmware >= 268) {
+    writeBytes(ASCII_GS, 'B', 1);
+  } else {
+    setPrintMode(INVERSE_MASK);
+  }
 }
 
 void Adafruit_Thermal::inverseOff() {
-#if PRINTER_FIRMWARE >= 268
-  writeBytes(ASCII_GS, 'B', 0);
-#else
-  unsetPrintMode(INVERSE_MASK);
-#endif
+  if (firmware >= 268) {
+    writeBytes(ASCII_GS, 'B', 0);
+  } else {
+    unsetPrintMode(INVERSE_MASK);
+  }
 }
 
 void Adafruit_Thermal::upsideDownOn() {
-#if PRINTER_FIRMWARE >= 268
-  writeBytes(ASCII_ESC, '{', 1);
-#else
-  setPrintMode(UPDOWN_MASK);
-#endif
+  if (firmware >= 268) {
+    writeBytes(ASCII_ESC, '{', 1);
+  } else {
+    setPrintMode(UPDOWN_MASK);
+  }
 }
 
 void Adafruit_Thermal::upsideDownOff() {
-#if PRINTER_FIRMWARE >= 268
-  writeBytes(ASCII_ESC, '{', 0);
-#else
-  unsetPrintMode(UPDOWN_MASK);
-#endif
+  if (firmware >= 268) {
+    writeBytes(ASCII_ESC, '{', 0);
+  } else {
+    unsetPrintMode(UPDOWN_MASK);
+  }
 }
 
 void Adafruit_Thermal::doubleHeightOn() { setPrintMode(DOUBLE_HEIGHT_MASK); }
@@ -402,15 +387,15 @@ void Adafruit_Thermal::justify(char value) {
 
 // Feeds by the specified number of lines
 void Adafruit_Thermal::feed(uint8_t x) {
-#if PRINTER_FIRMWARE >= 264
-  writeBytes(ASCII_ESC, 'd', x);
-  timeoutSet(dotFeedTime * charHeight);
-  prevByte = '\n';
-  column = 0;
-#else
-  while (x--)
-    write('\n'); // Feed manually; old firmware feeds excess lines
-#endif
+  if (firmware >= 264) {
+    writeBytes(ASCII_ESC, 'd', x);
+    timeoutSet(dotFeedTime * charHeight);
+    prevByte = '\n';
+    column = 0;
+  } else {
+    while (x--)
+      write('\n'); // Feed manually; old firmware feeds excess lines
+  }
 }
 
 // Feeds by the specified number of individual pixel rows
@@ -446,6 +431,29 @@ void Adafruit_Thermal::setSize(char value) {
 
   writeBytes(ASCII_GS, '!', size);
   prevByte = '\n'; // Setting the size adds a linefeed
+}
+
+// ESC 7 n1 n2 n3 Setting Control Parameter Command
+// n1 = "max heating dots" 0-255 -- max number of thermal print head
+//      elements that will fire simultaneously.  Units = 8 dots (minus 1).
+//      Printer default is 7 (64 dots, or 1/6 of 384-dot width), this code
+//      sets it to 11 (96 dots, or 1/4 of width).
+// n2 = "heating time" 3-255 -- duration that heating dots are fired.
+//      Units = 10 us.  Printer default is 80 (800 us), this code sets it
+//      to value passed (default 120, or 1.2 ms -- a little longer than
+//      the default because we've increased the max heating dots).
+// n3 = "heating interval" 0-255 -- recovery time between groups of
+//      heating dots on line; possibly a function of power supply.
+//      Units = 10 us.  Printer default is 2 (20 us), this code sets it
+//      to 40 (throttled back due to 2A supply).
+// More heating dots = more peak current, but faster printing speed.
+// More heating time = darker print, but slower printing speed and
+// possibly paper 'stiction'.  More heating interval = clearer print,
+// but slower printing speed.
+void Adafruit_Thermal::setHeatConfig(uint8_t dots, uint8_t time,
+                                     uint8_t interval) {
+  writeBytes(ASCII_ESC, '7');       // Esc 7 (print settings)
+  writeBytes(dots, time, interval); // Heating dots, heat time, heat interval
 }
 
 // Underlines of different weights can be produced:
@@ -570,41 +578,41 @@ void Adafruit_Thermal::sleep() {
 // Put the printer into a low-energy state after the given number
 // of seconds.
 void Adafruit_Thermal::sleepAfter(uint16_t seconds) {
-#if PRINTER_FIRMWARE >= 264
-  writeBytes(ASCII_ESC, '8', seconds, seconds >> 8);
-#else
-  writeBytes(ASCII_ESC, '8', seconds);
-#endif
+  if (firmware >= 264) {
+    writeBytes(ASCII_ESC, '8', seconds, seconds >> 8);
+  } else {
+    writeBytes(ASCII_ESC, '8', seconds);
+  }
 }
 
 // Wake the printer from a low-energy state.
 void Adafruit_Thermal::wake() {
   timeoutSet(0);   // Reset timeout counter
   writeBytes(255); // Wake
-#if PRINTER_FIRMWARE >= 264
-  delay(50);
-  writeBytes(ASCII_ESC, '8', 0, 0); // Sleep off (important!)
-#else
-  // Datasheet recommends a 50 mS delay before issuing further commands,
-  // but in practice this alone isn't sufficient (e.g. text size/style
-  // commands may still be misinterpreted on wake).  A slightly longer
-  // delay, interspersed with NUL chars (no-ops) seems to help.
-  for (uint8_t i = 0; i < 10; i++) {
-    writeBytes(0);
-    timeoutSet(10000L);
+  if (firmware >= 264) {
+    delay(50);
+    writeBytes(ASCII_ESC, '8', 0, 0); // Sleep off (important!)
+  } else {
+    // Datasheet recommends a 50 mS delay before issuing further commands,
+    // but in practice this alone isn't sufficient (e.g. text size/style
+    // commands may still be misinterpreted on wake).  A slightly longer
+    // delay, interspersed with NUL chars (no-ops) seems to help.
+    for (uint8_t i = 0; i < 10; i++) {
+      writeBytes(0);
+      timeoutSet(10000L);
+    }
   }
-#endif
 }
 
 // Check the status of the paper using the printer's self reporting
 // ability.  Returns true for paper, false for no paper.
 // Might not work on all printers!
 bool Adafruit_Thermal::hasPaper() {
-#if PRINTER_FIRMWARE >= 264
-  writeBytes(ASCII_ESC, 'v', 0);
-#else
-  writeBytes(ASCII_GS, 'r', 0);
-#endif
+  if (firmware >= 264) {
+    writeBytes(ASCII_ESC, 'v', 0);
+  } else {
+    writeBytes(ASCII_GS, 'r', 0);
+  }
 
   int status = -1;
   for (uint8_t i = 0; i < 10; i++) {

--- a/Adafruit_Thermal.h
+++ b/Adafruit_Thermal.h
@@ -74,15 +74,15 @@
 
 // Barcode types used with GS k m
 enum barcodes {
-  UPC_A,   //!< UPC-A barcode system. 11-12 char
-  UPC_E,   //!< UPC-E barcode system. 11-12 char
-  EAN13,   //!< EAN13 (JAN13) barcode system. 12-13 char
-  EAN8,    //!< EAN8 (JAN8) barcode system. 7-8 char
-  CODE39,  //!< CODE39 barcode system. 1<=num of chars
-  ITF,     //!< ITF barcode system. 1<=num of chars, must be an even number
-  CODABAR, //!< CODABAR barcode system. 1<=num<=255
-  CODE93,  //!< CODE93 barcode system. 1<=num<=255
-  CODE128, //!< CODE128 barcode system. 2<=num<=255
+  UPC_A,   ///< UPC-A barcode system. 11-12 char
+  UPC_E,   ///< UPC-E barcode system. 11-12 char
+  EAN13,   ///< EAN13 (JAN13) barcode system. 12-13 char
+  EAN8,    ///< EAN8 (JAN8) barcode system. 7-8 char
+  CODE39,  ///< CODE39 barcode system. 1<=num of chars
+  ITF,     ///< ITF barcode system. 1<=num of chars, must be an even number
+  CODABAR, ///< CODABAR barcode system. 1<=num<=255
+  CODE93,  ///< CODE93 barcode system. 1<=num<=255
+  CODE128, ///< CODE128 barcode system. 2<=num<=255
 };
 
 /*!

--- a/Adafruit_Thermal.h
+++ b/Adafruit_Thermal.h
@@ -72,17 +72,19 @@
 #define CODEPAGE_CP856 46       //!< Hebrew character code page
 #define CODEPAGE_CP874 47       //!< Thai character code page
 
-// Barcode types used with GS k m
+/*!
+ * Barcode types used with GS k m
+ */
 enum barcodes {
-  UPC_A,   ///< UPC-A barcode system. 11-12 char
-  UPC_E,   ///< UPC-E barcode system. 11-12 char
-  EAN13,   ///< EAN13 (JAN13) barcode system. 12-13 char
-  EAN8,    ///< EAN8 (JAN8) barcode system. 7-8 char
-  CODE39,  ///< CODE39 barcode system. 1<=num of chars
-  ITF,     ///< ITF barcode system. 1<=num of chars, must be an even number
-  CODABAR, ///< CODABAR barcode system. 1<=num<=255
-  CODE93,  ///< CODE93 barcode system. 1<=num<=255
-  CODE128, ///< CODE128 barcode system. 2<=num<=255
+  UPC_A,   /**< UPC-A barcode system. 11-12 char */
+  UPC_E,   /**< UPC-E barcode system. 11-12 char */
+  EAN13,   /**< EAN13 (JAN13) barcode system. 12-13 char */
+  EAN8,    /**< EAN8 (JAN8) barcode system. 7-8 char */
+  CODE39,  /**< CODE39 barcode system. 1<=num of chars */
+  ITF,     /**< ITF barcode system. 1<=num of chars, must be an even number */
+  CODABAR, /**< CODABAR barcode system. 1<=num<=255 */
+  CODE93,  /**< CODE93 barcode system. 1<=num<=255 */
+  CODE128, /**< CODE128 barcode system. 2<=num<=255 */
 };
 
 /*!

--- a/Adafruit_Thermal.h
+++ b/Adafruit_Thermal.h
@@ -5,27 +5,9 @@
 #ifndef ADAFRUIT_THERMAL_H
 #define ADAFRUIT_THERMAL_H
 
-/*!
- * *** EDIT THIS NUMBER ***  Printer firmware version is shown on test
- * page (hold feed button when connecting power).  Number used here is
- * integerized, e.g. 268 = 2.68 firmware.
- */
-#define PRINTER_FIRMWARE 268
-
 #include "Arduino.h"
 
-// Barcode types and charsets
-#if PRINTER_FIRMWARE >= 264
-#define UPC_A 65  //!< UPC-A barcode system. 11-12 char
-#define UPC_E 66  //!< UPC-E barcode system. 11-12 char
-#define EAN13 67  //!< EAN13 (JAN13) barcode system. 12-13 char
-#define EAN8 68   //!< EAN8 (JAN8) barcode system. 7-8 char
-#define CODE39 69 //!< CODE39 barcode system. 1<=num of chars
-#define ITF 70 //!< ITF barcode system. 1<=num of chars, must be an even number
-#define CODABAR 71 //!< CODABAR barcode system. 1<=num<=255
-#define CODE93 72  //!< CODE93 barcode system. 1<=num<=255
-#define CODE128 73 //!< CODE128 barcode system. 2<=num<=255
-
+// Internal character sets used with ESC R n
 #define CHARSET_USA 0           //!< American character set
 #define CHARSET_FRANCE 1        //!< French character set
 #define CHARSET_GERMANY 2       //!< German character set
@@ -44,6 +26,7 @@
 #define CHARSET_CROATIA 14      //!< Croatian character set
 #define CHARSET_CHINA 15        //!< Chinese character set
 
+// Character code tables used with ESC t n
 #define CODEPAGE_CP437 0    //!< USA, Standard Europe character code table
 #define CODEPAGE_KATAKANA 1 //!< Katakana (Japanese) character code table
 #define CODEPAGE_CP850 2    //!< Multilingual character code table
@@ -88,19 +71,19 @@
 #define CODEPAGE_THAI2 45       //!< Thai 2 character code page
 #define CODEPAGE_CP856 46       //!< Hebrew character code page
 #define CODEPAGE_CP874 47       //!< Thai character code page
-#else
-#define UPC_A 0
-#define UPC_E 1
-#define EAN13 2
-#define EAN8 3
-#define CODE39 4
-#define I25 5
-#define CODEBAR 6
-#define CODE93 7
-#define CODE128 8
-#define CODE11 9
-#define MSI 10
-#endif
+
+// Barcode types used with GS k m
+enum barcodes {
+  UPC_A,   //!< UPC-A barcode system. 11-12 char
+  UPC_E,   //!< UPC-E barcode system. 11-12 char
+  EAN13,   //!< EAN13 (JAN13) barcode system. 12-13 char
+  EAN8,    //!< EAN8 (JAN8) barcode system. 7-8 char
+  CODE39,  //!< CODE39 barcode system. 1<=num of chars
+  ITF,     //!< ITF barcode system. 1<=num of chars, must be an even number
+  CODABAR, //!< CODABAR barcode system. 1<=num<=255
+  CODE93,  //!< CODE93 barcode system. 1<=num<=255
+  CODE128, //!< CODE128 barcode system. 2<=num<=255
+};
 
 /*!
  * Driver for the thermal printer
@@ -126,9 +109,9 @@ public:
     write(uint8_t c);
   void
     /*!
-     * @param heatTime how much time to spend heating up the printer
+     * @param version firmware version as integer, e.g. 268 = 2.68 firmware
      */
-    begin(uint8_t heatTime=120),
+    begin(uint16_t version=268),
     /*!
      * @brief Disables bold text
      */
@@ -268,6 +251,13 @@ public:
      */
     setTimes(unsigned long, unsigned long),
     /*!
+     * @brief Sets print head heating configuration
+     * @param dots max printing dots, 8 dots per increment
+     * @param time heating time, 10us per increment
+     * @param interval heating interval, 10 us per increment
+     */
+    setHeatConfig(uint8_t dots=11, uint8_t time=120, uint8_t interval=40),
+    /*!
      * @brief Puts the printer into a low-energy state immediately
      */
     sleep(),
@@ -344,6 +334,7 @@ private:
       barcodeHeight, // Barcode height in dots, not including text
       maxChunkHeight,
       dtrPin;         // DTR handshaking pin (experimental)
+  uint16_t firmware;  // Firmware version
   boolean dtrEnabled; // True if DTR pin set & printer initialized
   unsigned long
       resumeTime,   // Wait until micros() exceeds this before sending byte

--- a/examples/A_printertest/A_printertest.ino
+++ b/examples/A_printertest/A_printertest.ino
@@ -6,9 +6,6 @@
   This is to support newer & more board types, especially ones that don't
   support SoftwareSerial (e.g. Arduino Due).  You can pass any Stream
   (e.g. Serial1) to the printer constructor.  See notes below.
-
-  You may need to edit the PRINTER_FIRMWARE value in Adafruit_Thermal.h
-  to match your printer (hold feed button on powerup for test page).
   ------------------------------------------------------------------------*/
 
 #include "Adafruit_Thermal.h"


### PR DESCRIPTION
**BREAKING CHANGE**

As requested, refactors firmware version to be settable without use of changing `#define`. It can now be passed in as a parameter to `begin()`. The existing heat time parameter was removed and instead a new `setHeatConfig()` function has been added.

Nothing new in the way of features, just confirming existing example still works:

![version_test](https://user-images.githubusercontent.com/8755041/114088847-4fefc100-986a-11eb-857c-713e9134462a.jpg)
