### PR TITLE
Misc fixes.

### DIFF
--- a/Adafruit_Thermal.cpp
+++ b/Adafruit_Thermal.cpp
@@ -82,11 +82,11 @@ void Adafruit_Thermal::timeoutSet(unsigned long x) {
 void Adafruit_Thermal::timeoutWait() {
   if (dtrEnabled) {
     while (digitalRead(dtrPin) == HIGH) {
-      delay(1);
+      yield();
     };
   } else {
     while ((long)(micros() - resumeTime) < 0L) {
-      delay(1);
+      yield();
     }; // (syntax is rollover-proof)
   }
 }

--- a/Adafruit_Thermal.cpp
+++ b/Adafruit_Thermal.cpp
@@ -82,11 +82,11 @@ void Adafruit_Thermal::timeoutSet(unsigned long x) {
 void Adafruit_Thermal::timeoutWait() {
   if (dtrEnabled) {
     while (digitalRead(dtrPin) == HIGH) {
-      delay(0);
+      delay(1);
     };
   } else {
     while ((long)(micros() - resumeTime) < 0L) {
-      delay(0);
+      delay(1);
     }; // (syntax is rollover-proof)
   }
 }

--- a/Adafruit_Thermal.cpp
+++ b/Adafruit_Thermal.cpp
@@ -81,11 +81,13 @@ void Adafruit_Thermal::timeoutSet(unsigned long x) {
 // This function waits (if necessary) for the prior task to complete.
 void Adafruit_Thermal::timeoutWait() {
   if (dtrEnabled) {
-    while (digitalRead(dtrPin) == HIGH)
-      ;
+    while (digitalRead(dtrPin) == HIGH) {
+      delay(0);
+    };
   } else {
-    while ((long)(micros() - resumeTime) < 0L)
-      ; // (syntax is rollover-proof)
+    while ((long)(micros() - resumeTime) < 0L) {
+      delay(0);
+    }; // (syntax is rollover-proof)
   }
 }
 
@@ -182,20 +184,6 @@ void Adafruit_Thermal::begin(uint16_t version) {
   reset();
 
   setHeatConfig();
-
-  // Print density description from manual:
-  // DC2 # n Set printing density
-  // D4..D0 of n is used to set the printing density.  Density is
-  // 50% + 5% * n(D4-D0) printing density.
-  // D7..D5 of n is used to set the printing break time.  Break time
-  // is n(D7-D5)*250us.
-  // (Unsure of the default value for either -- not documented)
-
-#define printDensity 10
-
-#define printBreakTime 2
-
-  writeBytes(ASCII_DC2, '#', (printBreakTime << 5) | printDensity);
 
   // Enable DTR pin if requested
   if (dtrPin < 255) {
@@ -454,6 +442,17 @@ void Adafruit_Thermal::setHeatConfig(uint8_t dots, uint8_t time,
                                      uint8_t interval) {
   writeBytes(ASCII_ESC, '7');       // Esc 7 (print settings)
   writeBytes(dots, time, interval); // Heating dots, heat time, heat interval
+}
+
+// Print density description from manual:
+// DC2 # n Set printing density
+// D4..D0 of n is used to set the printing density.  Density is
+// 50% + 5% * n(D4-D0) printing density.
+// D7..D5 of n is used to set the printing break time.  Break time
+// is n(D7-D5)*250us.
+// (Unsure of the default value for either -- not documented)
+void Adafruit_Thermal::setPrintDensity(uint8_t density, uint8_t breakTime) {
+  writeBytes(ASCII_DC2, '#', (density << 5) | breakTime);
 }
 
 // Underlines of different weights can be produced:

--- a/Adafruit_Thermal.cpp
+++ b/Adafruit_Thermal.cpp
@@ -165,12 +165,6 @@ size_t Adafruit_Thermal::write(uint8_t c) {
   return 1;
 }
 
-/*!
-  @def printDensity
-  Printing density, default: 100% (? can go higher, text is darker but fuzzy)
-  @def printBreakTime
-  Printing break time. Default: 500 uS
-*/
 void Adafruit_Thermal::begin(uint16_t version) {
 
   firmware = version;

--- a/Adafruit_Thermal.h
+++ b/Adafruit_Thermal.h
@@ -260,6 +260,12 @@ public:
      */
     setHeatConfig(uint8_t dots=11, uint8_t time=120, uint8_t interval=40),
     /*!
+     * @brief Sets print density
+     * @param density printing density
+     * @param breakTime printing break time
+     */
+    setPrintDensity(uint8_t density=10, uint8_t breakTime=2),
+    /*!
      * @brief Puts the printer into a low-energy state immediately
      */
     sleep(),


### PR DESCRIPTION
A couple of fixes here.

* Fix #23. The busy wait loop was causing WDT reset on ESP8266. Added a `delay(0)` in the loop to allow ESP8266's implementation to yield as needed. This way don't need any pre-processor logic.
* Fix #38. Was not able to reproduce this, but based on conversation in issue thread it was related to calling an unsupported option `DC2 *` in `begin()`. Moved that configuration to a new function `setPrintDensity()` and then don't call it by default. Resulting prints look fine without it.

Here's an example WDT reset just for records:
![Screenshot from 2021-04-09 13-49-52](https://user-images.githubusercontent.com/8755041/114274236-4bdeb300-99d2-11eb-8b3a-88c9a04eda98.png)
